### PR TITLE
Update README example to use syntax for @v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
       -
         name: Run Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v2
+        uses: crazy-max/ghaction-github-labeler@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml


### PR DESCRIPTION
The syntax example on the README was updated for v3, but had the action docker tag of v2 still (forgive me if I'm misunderstanding something, though)

Thanks for your time and all you do 👍