### PR TITLE
Fix label rename

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -218,7 +218,7 @@ class Labeler {
     updateLabel(label) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const params = Object.assign(Object.assign({}, github.context.repo), { current_name: label.name, name: label.name, color: label.color, description: label.description, mediaType: {
+                const params = Object.assign(Object.assign({}, github.context.repo), { name: label.name, color: label.color, description: label.description, mediaType: {
                         previews: ['symmetra']
                     } });
                 yield this.octokit.issues.updateLabel(params);
@@ -233,7 +233,7 @@ class Labeler {
     renameLabel(label) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const params = Object.assign(Object.assign({}, github.context.repo), { current_name: label.from_name, name: label.name, color: label.color, description: label.description, mediaType: {
+                const params = Object.assign(Object.assign({}, github.context.repo), { new_name: label.name, name: label.from_name, color: label.color, description: label.description, mediaType: {
                         previews: ['symmetra']
                     } });
                 yield this.octokit.issues.updateLabel(params);

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -134,7 +134,6 @@ export class Labeler {
     try {
       const params = {
         ...github.context.repo,
-        current_name: label.name,
         name: label.name,
         color: label.color,
         description: label.description,
@@ -154,8 +153,8 @@ export class Labeler {
     try {
       const params = {
         ...github.context.repo,
-        current_name: label.from_name,
-        name: label.name,
+        new_name: label.name,
+        name: label.from_name,
         color: label.color,
         description: label.description,
         mediaType: {


### PR DESCRIPTION
- Now using correct api fields, `current_name` vs `new_name`.
- Fixes #120

Tried to run action from my fork and these little changes worked well.