### PR TITLE
The github-token parameter has a default value and it's not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   github-token:
     description: 'GitHub Token as provided by secrets'
     default: ${{ github.token }}
-    required: true
+    required: false
   yaml-file:
     description: 'Path to YAML file containing labels definitions'
     default: '.github/labels.yml'


### PR DESCRIPTION
Hello

Thank you for sharing this action.

I made one very small modification:
The `github-token` has a default value of `${{ github.token }}`,
as such, it is not required to be used by the user.

> Note, `docker buildx bake validate` throws an error on my station,
> with or without my modification.