### PR TITLE
The github-token parameter has a default value and it's not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   github-token:
     description: 'GitHub Token as provided by secrets'
     default: ${{ github.token }}
-    required: true
+    required: false
   yaml-file:
     description: 'Path to YAML file containing labels definitions'
     default: '.github/labels.yml'


### PR DESCRIPTION
Hello

Thank you for this great action.
A small contribution, the `github-token` parameter has a default value, so it can be marked as not required.

