### PR TITLE
ensure lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+* text eol=lf working-tree-encoding=UTF-8
+*.png binary
 /dist/** linguist-generated=true
 /lib/** linguist-generated=true


### PR DESCRIPTION
preferred to always be explicit. Git user config could potentially add `crlf` on windows